### PR TITLE
Refactor login and logout

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -9,7 +9,6 @@ const Layout = lazy(() => import("./routes/Layout.jsx"));
 const AttendanceDashboard = lazy(
   () => import("./routes/AttendanceDashboard.jsx"),
 );
-const Login = lazy(() => import("./routes/Login"));
 const CreatePatient = lazy(() => import("./routes/CreatePatient.jsx"));
 const Logout = lazy(() => import("./routes/Logout"));
 const AdminProfile = lazy(() => import("./routes/AdminProfile"));
@@ -41,7 +40,6 @@ const PatientSkinSensoryAid = lazy(
   () => import("./routes/PatientSkinSensoryAid"),
 );
 const PatientNutrition = lazy(() => import("./routes/PatientNutrition"));
-const Unauthorized = lazy(() => import("./routes/Unauthorized.jsx"));
 const PageNotFound = lazy(() => import("./routes/PageNotFound.jsx"));
 const InstructorProfile = lazy(() => import("./routes/InstructorProfile.jsx"));
 const ClassCodeEnrollment = lazy(
@@ -69,10 +67,8 @@ function App() {
     <Suspense fallback={<Spinner />}>
       <Routes>
         {/* public routes */}
-        <Route path="login" element={<Login />} />
         <Route path="logout" element={<Logout />} />
         <Route path="enroll" element={<ClassCodeEnrollment />} />
-        <Route path="unauthorized" element={<Unauthorized />} />
         <Route path="attendance/checkin" element={<AttendanceCheckin />} />
         <Route path="attendance/failed" element={<AttendanceFailed />} />
         <Route path="attendance" element={<AttendanceDashboard />} />

--- a/frontend/src/authConfig.js
+++ b/frontend/src/authConfig.js
@@ -3,7 +3,7 @@ export const msalConfig = {
     clientId: import.meta.env.VITE_AD_CLIENTID,
     authority: `https://login.microsoftonline.com/${import.meta.env.VITE_AD_TENANTID}`,
     redirectUri: import.meta.env.VITE_AD_REDIRECTURI,
-    navigateToLoginRequestUrl: false,
+    navigateToLoginRequestUrl: true,
   },
   cache: {
     cacheLocation: "sessionStorage",

--- a/frontend/src/components/IdleSessionManager.jsx
+++ b/frontend/src/components/IdleSessionManager.jsx
@@ -1,30 +1,15 @@
-import { IdleTimerProvider } from 'react-idle-timer';
-import { useNavigate } from 'react-router-dom';
-import { PublicClientApplication } from '@azure/msal-browser';
-import { msalConfig } from '../authConfig';
-
-const pca = new PublicClientApplication(msalConfig);
+import PropTypes from "prop-types";
+import { IdleTimerProvider } from "react-idle-timer";
+import { useNavigate } from "react-router-dom";
 
 export default function IdleSessionManager({ children }) {
   const navigate = useNavigate();
 
   const handleOnIdle = () => {
-    console.log("Idle for 5 minutes — logging out.");
+    console.info("Idle for 15 minutes — logging out.");
 
-    // Clear MSAL tokens
-    try {
-      pca.logoutPopup?.();
-      pca.logoutRedirect?.();
-    } catch (err) {
-      console.warn("MSAL logout failed, continuing with local cleanup.");
-    }
-
-    // Clear local/session storage
-    localStorage.clear();
-    sessionStorage.clear();
-
-    // Redirect to login
-    navigate("/login", { replace: true });
+    // Navigate to logout page
+    navigate("/logout");
   };
 
   return (
@@ -37,3 +22,7 @@ export default function IdleSessionManager({ children }) {
     </IdleTimerProvider>
   );
 }
+
+IdleSessionManager.propTypes = {
+  children: PropTypes.node,
+};

--- a/frontend/src/components/Nav.jsx
+++ b/frontend/src/components/Nav.jsx
@@ -1,7 +1,6 @@
 import { Link, useLocation, useNavigate } from "react-router-dom";
 import { useUser } from "../context/UserContext";
 import { useCallback, memo, useState, useEffect, useMemo } from "react";
-import { getAssessmentCount } from "../utils/assessmentStorage";
 import PropTypes from "prop-types";
 import api from "../utils/api";
 
@@ -259,7 +258,6 @@ const Nav = memo(function Nav() {
   const [showCampusDropdown, setShowCampusDropdown] = useState(false);
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
   const [showLogoutModal, setShowLogoutModal] = useState(false);
-  const [pendingLogout, setPendingLogout] = useState(false);
 
   // =========================================
   // Derived State
@@ -342,7 +340,6 @@ const Nav = memo(function Nav() {
     if (storedShift) {
       setSelectedShift(storedShift);
     }
-    
 
     if (storedRotation) {
       try {
@@ -366,26 +363,10 @@ const Nav = memo(function Nav() {
       sessionStorage.removeItem("selectedRotation");
       setSelectedShift("");
       setSelectedRotation("");
-      window.dispatchEvent(new Event('shiftChanged'));
+      window.dispatchEvent(new Event("shiftChanged"));
       navigate("/");
     }
   }, [navigate]);
-
-  const handleLogout = useCallback(() => {
-    const count = getAssessmentCount();
-
-    if (count > 0) {
-      setPendingLogout(true);
-      setShowLogoutModal(true);
-      return;
-    }
-
-    sessionStorage.removeItem("selectedShift");
-    sessionStorage.removeItem("selectedRotation");
-    setSelectedShift("");
-    setSelectedRotation("");
-    navigate("/logout", { replace: true });
-  }, [logout]);
 
   const toggleMobileMenu = useCallback(() => {
     setIsMobileMenuOpen((prev) => !prev);
@@ -784,7 +765,7 @@ const Nav = memo(function Nav() {
             }}
             onMouseEnter={handleMouseEnter}
             onMouseLeave={handleMouseLeave}
-            onClick={handleLogout}
+            onClick={logout}
           >
             Log out
           </button>
@@ -830,7 +811,7 @@ const Nav = memo(function Nav() {
                         setShowLogoutModal(false);
                         sessionStorage.removeItem("selectedShift");
                         setSelectedShift("");
-                        navigate("/logout", { replace: true });
+                        navigate("/logout");
                       }}
                     >
                       Log Out Anyway

--- a/frontend/src/context/UserContext.jsx
+++ b/frontend/src/context/UserContext.jsx
@@ -1,4 +1,5 @@
 import { createContext, useContext, useState, useEffect, useMemo } from "react";
+import { useNavigate } from "react-router";
 import { useMsal } from "@azure/msal-react";
 import api from "../utils/api";
 import PropTypes from "prop-types";
@@ -52,11 +53,8 @@ const fetchCampusForInstructor = async () => {
 export function UserProvider({ children }) {
   const [user, setUser] = useState(null);
   const [loading, setLoading] = useState(true);
-  const [isLoggingOut, setIsLoggingOut] = useState(() => {
-    // Check localStorage on initialization
-    return localStorage.getItem("isLoggingOut") === "true";
-  });
   const { instance, accounts } = useMsal();
+  const navigate = useNavigate();
 
   //helper function for making access control easier
   const isAdmin = useMemo(() => {
@@ -68,19 +66,6 @@ export function UserProvider({ children }) {
   }, [user]);
 
   useEffect(() => {
-    // Don't re-initialize user if we're in the process of logging out
-    if (isLoggingOut) {
-      // Actively clear any accounts that MSAL might have restored
-      if (accounts.length > 0) {
-        // Clear sessionStorage again to ensure MSAL cache is gone
-        sessionStorage.clear();
-      }
-
-      setUser(null);
-      setLoading(false);
-      return;
-    }
-
     const fetchUserProfile = async () => {
       if (accounts.length > 0) {
         const account = accounts[0];
@@ -136,16 +121,14 @@ export function UserProvider({ children }) {
     };
 
     fetchUserProfile();
-  }, [accounts, isLoggingOut, instance]);
+  }, [accounts, instance]);
 
   const login = (userData) => {
     setUser(userData);
   };
 
   const logout = () => {
-    localStorage.setItem("isLoggingOut", "true");
-    setIsLoggingOut(true);
-    setUser(null);
+    navigate("/logout");
   };
 
   // Function to refresh user profile after enrollment

--- a/frontend/src/routes/AttendanceFailed.jsx
+++ b/frontend/src/routes/AttendanceFailed.jsx
@@ -22,7 +22,7 @@ export default function AttendanceFailed() {
           <button
             className="attendance-checkin-button secondary"
             type="button"
-            onClick={() => navigate("/login", { replace: true })}
+            onClick={() => navigate("/")}
           >
             Go to login
           </button>

--- a/frontend/src/routes/ClassCodeEnrollment.jsx
+++ b/frontend/src/routes/ClassCodeEnrollment.jsx
@@ -86,7 +86,7 @@ export default function ClassCodeEnrollment() {
       if (response.data.needsApproval) {
         // Instructor request submitted
         alert(response.data.message);
-        navigate("/login");
+        navigate("/");
       } else {
         // Successfully enrolled, reload page to fetch profile
         window.location.href = "/";

--- a/frontend/src/routes/Logout.jsx
+++ b/frontend/src/routes/Logout.jsx
@@ -1,38 +1,12 @@
-import { useEffect, useRef } from 'react';
-import { useMsal } from '@azure/msal-react';
-import { useUser } from '../context/UserContext';
+import { useEffect } from "react";
 
 export default function Logout() {
-  const { instance } = useMsal();
-  const { logout } = useUser();
-  const hasLoggedOut = useRef(false);
-
   useEffect(() => {
-    const handleLogout = () => {
-      if (hasLoggedOut.current) {
-        return;
-      }
-      hasLoggedOut.current = true;
-      
-      // Set logging out flag immediately (persists in localStorage)
-      logout();
-      
-      const accounts = instance.getAllAccounts();
-      
-      // Clear all MSAL accounts from cache
-      accounts.forEach(account => {
-        instance.setActiveAccount(null);
-      });
-      
-      // Clear all session storage (this removes MSAL cache too since we use sessionStorage)
-      sessionStorage.clear();
+    // Clear all session storage (and MSAL cache)
+    sessionStorage.clear();
+    // Force a hard navigation to the home page
+    window.location.replace("/");
+  }, []);
 
-      // Force a hard navigation to login to ensure clean state
-      window.location.replace('/login');
-    };
-    
-    handleLogout();
-  }, [instance, logout]);
-
-  return null; // note: this will be a message eventually 
+  return null;
 }

--- a/frontend/src/routes/Register.jsx
+++ b/frontend/src/routes/Register.jsx
@@ -92,7 +92,7 @@ export default function Registration() {
         `${response?.data?.message || "Success! Account has been created"}`,
       );
       setErrMsg("");
-      setTimeout(() => navigate("/login"), 3000);
+      setTimeout(() => navigate("/"), 3000);
     } catch (err) {
       if (!err?.response) {
         setErrMsg("No Server Response");
@@ -304,7 +304,7 @@ export default function Registration() {
 
         <p style={styles.loginPrompt}>
           Already have an account?{" "}
-          <span onClick={() => navigate("/login")} style={styles.loginLink}>
+          <span onClick={() => navigate("/")} style={styles.loginLink}>
             Login here
           </span>
           .

--- a/frontend/src/routes/RegistrationInstructor.jsx
+++ b/frontend/src/routes/RegistrationInstructor.jsx
@@ -43,7 +43,7 @@ export default function RegistrationInstructor() {
         `${response?.data?.message || "Success! Account has been created"}`,
       );
       setErrMsg("");
-      setTimeout(() => navigate("/login"), 3000);
+      setTimeout(() => navigate("/"), 3000);
     } catch (err) {
       if (!err?.response) {
         setErrMsg("No Server Response");
@@ -204,7 +204,7 @@ export default function RegistrationInstructor() {
 
         <p style={styles.loginPrompt}>
           Already have an account?{" "}
-          <span onClick={() => navigate("/login")} style={styles.loginLink}>
+          <span onClick={() => navigate("/")} style={styles.loginLink}>
             Login here
           </span>
           .

--- a/frontend/src/routes/RequireAuth.jsx
+++ b/frontend/src/routes/RequireAuth.jsx
@@ -14,8 +14,6 @@ const RequireAuth = ({ allowedRoles }) => {
   const { user, loading } = useUser();
   const navigate = useNavigate();
 
-  console.debug({ isAuthenticated, inProgress, loading });
-
   if (!isAuthenticated && inProgress === "none") {
     return (
       <Suspense fallback={<Spinner />}>

--- a/frontend/src/routes/RequireAuth.jsx
+++ b/frontend/src/routes/RequireAuth.jsx
@@ -1,17 +1,27 @@
+import { Suspense, lazy } from "react";
 import { useIsAuthenticated, useMsal } from "@azure/msal-react";
-import { useLocation, Navigate, Outlet } from "react-router-dom";
+import { Outlet, useNavigate } from "react-router-dom";
 import { useUser } from "../context/UserContext";
 import Spinner from "../components/Spinner";
 import PropTypes from "prop-types";
+
+const Login = lazy(() => import("./Login"));
+const Unauthorized = lazy(() => import("./Unauthorized"));
 
 const RequireAuth = ({ allowedRoles }) => {
   const isAuthenticated = useIsAuthenticated();
   const { inProgress } = useMsal();
   const { user, loading } = useUser();
-  const location = useLocation();
+  const navigate = useNavigate();
+
+  console.debug({ isAuthenticated, inProgress, loading });
 
   if (!isAuthenticated && inProgress === "none") {
-    return <Navigate to="/login" state={{ from: location }} replace />;
+    return (
+      <Suspense fallback={<Spinner />}>
+        <Login />
+      </Suspense>
+    );
   }
 
   if (loading) {
@@ -20,7 +30,7 @@ const RequireAuth = ({ allowedRoles }) => {
 
   // Redirect to enrollment if user needs to enroll
   if (user?.needsEnrollment) {
-    return <Navigate to="/enroll" state={{ from: location }} replace />;
+    navigate("/enroll");
   }
 
   // Check if user has required role OR is a valid student (no roles but has classId)
@@ -31,7 +41,11 @@ const RequireAuth = ({ allowedRoles }) => {
     user && !user.isInstructor && user.classId && user.isValid !== false;
 
   if (!(hasRequiredRole || isValidStudent)) {
-    return <Navigate to="/unauthorized" state={{ from: location }} replace />;
+    return (
+      <Suspense fallback={<Spinner />}>
+        <Unauthorized />
+      </Suspense>
+    );
   }
 
   return <Outlet />;

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -1,33 +1,33 @@
-import axios from 'axios';
-import msalInstance from '../msalInstance';
-import { loginRequest } from '../authConfig';
+import axios from "axios";
+import msalInstance from "../msalInstance";
+import { loginRequest } from "../authConfig";
 
 const APIHOST = import.meta.env.VITE_API_URL;
 const IMAGEHOST = import.meta.env.VITE_FUNCTION_URL;
 
 const api = axios.create({
-  baseURL: APIHOST
+  baseURL: APIHOST,
 });
 
 // Add request interceptor to include MSAL token
 api.interceptors.request.use(
   async (config) => {
     const accounts = msalInstance.getAllAccounts();
-    const adminCampusId = localStorage.getItem('adminCampusId');
+    const adminCampusId = localStorage.getItem("adminCampusId");
     if (adminCampusId) {
-      config.headers['X-Campus-Id'] = adminCampusId;
+      config.headers["X-Campus-Id"] = adminCampusId;
     }
     if (accounts.length > 0) {
       try {
         const response = await msalInstance.acquireTokenSilent({
           ...loginRequest,
-          account: accounts[0]
+          account: accounts[0],
         });
         config.headers.Authorization = `Bearer ${response.accessToken}`;
       } catch (error) {
-        console.error('Error acquiring token silently:', error);
+        console.error("Error acquiring token silently:", error);
         // If silent token acquisition fails, redirect to login
-        if (error.name === 'InteractionRequiredAuthError') {
+        if (error.name === "InteractionRequiredAuthError") {
           await msalInstance.acquireTokenRedirect(loginRequest);
         }
       }
@@ -36,7 +36,7 @@ api.interceptors.request.use(
   },
   (error) => {
     return Promise.reject(error);
-  }
+  },
 );
 
 // Add response interceptor to handle 401 errors
@@ -44,52 +44,54 @@ api.interceptors.response.use(
   (response) => response,
   async (error) => {
     const originalRequest = error.config;
-    
+
     if (error.response?.status === 401 && !originalRequest._retry) {
       originalRequest._retry = true;
-      
+
       // Try to acquire a new token
       const accounts = msalInstance.getAllAccounts();
       if (accounts.length > 0) {
         try {
           const response = await msalInstance.acquireTokenSilent({
             ...loginRequest,
-            account: accounts[0]
+            account: accounts[0],
           });
           originalRequest.headers.Authorization = `Bearer ${response.accessToken}`;
           return api(originalRequest);
         } catch (tokenError) {
-          console.error('Token refresh failed:', tokenError);
+          console.error("Token refresh failed:", tokenError);
           // Only logout if token refresh fails with interaction required
-          if (tokenError.name === 'InteractionRequiredAuthError') {
-            window.location.href = '/login';
+          if (tokenError.name === "InteractionRequiredAuthError") {
+            window.location.href = "/";
           }
         }
       } else {
         // No accounts, redirect to login
-        window.location.href = '/login';
+        window.location.href = "/";
       }
     }
     return Promise.reject(error);
-  }
+  },
 );
 
 // Image upload function
 export const uploadPatientImage = async (imageFile) => {
   const formData = new FormData();
-  formData.append('image', imageFile);
-  
+  formData.append("image", imageFile);
+
   const response = await axios.post(`${IMAGEHOST}/api/ImageUpload`, formData, {
     headers: {
-      'Content-Type': 'multipart/form-data'
-    }
+      "Content-Type": "multipart/form-data",
+    },
   });
   return response.data;
 };
 
 // Get image URL function
 export const getPatientImageUrl = async (imageFilename) => {
-  const response = await axios.get(`${IMAGEHOST}/api/GetImageUrl/${imageFilename}`);
+  const response = await axios.get(
+    `${IMAGEHOST}/api/GetImageUrl/${imageFilename}`,
+  );
   return response.data;
 };
 
@@ -100,12 +102,18 @@ export const getDoctorOrders = async (patientId) => {
 };
 
 export const createDoctorOrder = async (patientId, orderText) => {
-  const response = await api.post(`/api/patients/${patientId}/doctororders`, { orderText, patientId });
+  const response = await api.post(`/api/patients/${patientId}/doctororders`, {
+    orderText,
+    patientId,
+  });
   return response.data;
 };
 
 export const updateDoctorOrder = async (patientId, orderId, orderText) => {
-  const response = await api.put(`/api/patients/${patientId}/doctororders/${orderId}`, { orderText, patientId, doctorOrderId: orderId });
+  const response = await api.put(
+    `/api/patients/${patientId}/doctororders/${orderId}`,
+    { orderText, patientId, doctorOrderId: orderId },
+  );
   return response.data;
 };
 
@@ -119,7 +127,7 @@ export const deleteDoctorOrder = async (patientId, orderId) => {
 
 export const getUnreadDoctorOrderCount = async (patientId) => {
   const orders = await getDoctorOrders(patientId);
-  return orders.filter(order => !order.readAt).length;
+  return orders.filter((order) => !order.readAt).length;
 };
 
 export default api;


### PR DESCRIPTION
This PR removes the `/login` and `/unauthorized` routes. Instead they are rendered as child components of `<RequireAuth />`. I touched up files that made reference to theses routes and also cleaned up the logout path.

This change allows the login page to be displayed on any route and after login the user will be redirected back to the route that they initiated the login from. 

For example if the user clicked a link that brought them to `/instructor/calendar`. They are not logged in so the login component is displayed. After they complete login, they are brought back to `/instructor/calendar`.